### PR TITLE
Created a Podspec file so this lib can be installed using cocoapods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 22/01/14 Gurpreet Singh Mundi (@Gurmundi7) 
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions: 
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 

--- a/UIImageView+AnimationCompletionBlock.podspec
+++ b/UIImageView+AnimationCompletionBlock.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "UIImageView-AnimationCompletionBlock"
+  s.name         = "UIImageView+AnimationCompletionBlock"
   s.version      = "1.0.0"
   s.summary      = "Category on UIImageView that provides an alternative to startAnimation that allows a completion block."
   s.homepage     = "https://github.com/gurmundi7/UIImageView-AnimationCompletionBlock"

--- a/UIImageView-AnimationCompletionBlock.podspec
+++ b/UIImageView-AnimationCompletionBlock.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "UIImageView-AnimationCompletionBlock"
+  s.version      = "1.0.0"
+  s.summary      = "Category on UIImageView that provides an alternative to startAnimation that allows a completion block."
+  s.homepage     = "https://github.com/gurmundi7/UIImageView-AnimationCompletionBlock"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "Gurpreet Singh Mundi" => "unknown" }
+  s.platform     = :ios
+  s.ios.deployment_target = "5.1.1"
+  s.source       = { :git => "https://github.com/gurmundi7/UIImageView-AnimationCompletionBlock" }
+  s.public_header_files = 'imageViewAnimationCompletion/UIImageView+AnimationCompletion.h'
+  s.source_files = 'imageViewAnimationCompletion/UIImageView+AnimationCompletion.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
This allows projects using cocoapods to install this lib via the Podfile.

To make it better and to be able to contribute the podspec to cocoapods, it would be best if you would tag the current version with a git tag as 1.0.0, so it can be installed by referencing the version number instead of by referencing the github url.
